### PR TITLE
Fixed path to router script for the latest php 7.1.12 version.

### DIFF
--- a/watch.cmd
+++ b/watch.cmd
@@ -18,7 +18,7 @@ SET sassc_style=nested
 SET watch_directory=scss
 
 REM Launch local php web server in background.
-START "" /B %php% -S localhost:8888 -t www router.php || ECHO ERROR while launching %php% web server. && EXIT /B 1
+START "" /B %php% -S localhost:8888 -t www ..\router.php || ECHO ERROR while launching %php% web server. && EXIT /B 1
 
 REM Rebuild scss on the launch once and watch for any scss directory changes indefinitely.
 :loop


### PR DESCRIPTION
The server now looks for the router.php in the given www dir.
It should be tested on Windows first, with the latest PHP version.